### PR TITLE
Fix 'sensor not required' warning

### DIFF
--- a/templates/_admin_lib_js.tpl
+++ b/templates/_admin_lib_js.tpl
@@ -1,3 +1,3 @@
 {# Javascript files for the admin #}
-<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key={{ m.config.mod_geo.api_key.value|escape }}&sensor=false"></script>
+<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key={{ m.config.mod_geo.api_key.value|escape }}"></script>
 {% lib "js/admin-geo.js" %}


### PR DESCRIPTION
See https://developers.google.com/maps/documentation/javascript/error-messages
