### PR TITLE
Country only set address on map

### DIFF
--- a/lib/js/admin-geo.js
+++ b/lib/js/admin-geo.js
@@ -62,7 +62,8 @@
                     city: $('#address_city').val(),
                     postcode: $('#address_postcode').val(),
                     state: $('#address_state').val(),
-                    country: $('#address_country option:selected').text()
+                    country: $('#address_country option:selected').text(),
+                    country_name: $('#address_country option:selected').text(),
                     z_delegate: 'mod_geo'
                 };
                 z_notify("address_lookup", args);

--- a/lib/js/admin-geo.js
+++ b/lib/js/admin-geo.js
@@ -62,7 +62,7 @@
                     city: $('#address_city').val(),
                     postcode: $('#address_postcode').val(),
                     state: $('#address_state').val(),
-                    country: $('#address_country').val(),
+                    country: $('#address_country option:selected').text()
                     z_delegate: 'mod_geo'
                 };
                 z_notify("address_lookup", args);


### PR DESCRIPTION
"Set to my entered address" does not work when only country is selected. The country field uses country codes (ex: nl,uk,de etc). The google maps api does not know how to convert those. My suggestion would be to use the text of the selected option and send that to the google maps api. This seems to work better.